### PR TITLE
Update limitations to include checkboxes for common project configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Module description from config.json
 
 <!-- Mention any limitations to this module that users may expect, e.g. won't work with repating instances or events, won't work with signature fields -->
 
+If **checked**, you can expect the module to account for these common project variants:
+- [ ] Longitudinal projects
+- [ ] Repeating events
+- [ ] Repeating instances
+
 ## System Configuration
 
 <!-- generated from config.json -->


### PR DESCRIPTION
As per 2026-03-02 DCC Managers meeting.  
When creating an external module, if it's intended to interface with a project, the developer will typically design it from the beginning with these contexts (longitudinal, repeatable events, repeatable instances) in mind.

Hardcoded field/form names were mentioned in the meeting, but since this template is for _new_ modules, developers shouldn't be hardcoding these to begin with.

Long term I think these could be integrated into `config.json` for an alert/warning system integrated into the project setup.